### PR TITLE
Acquire a lock on the upgrade script.

### DIFF
--- a/scripts/credentials.sh
+++ b/scripts/credentials.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/credentials_restart.sh
+++ b/scripts/credentials_restart.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/discovery.sh
+++ b/scripts/discovery.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/discovery_restart.sh
+++ b/scripts/discovery_restart.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/ecommerce.sh
+++ b/scripts/ecommerce.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/ecommerce_restart.sh
+++ b/scripts/ecommerce_restart.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/edxapp.sh
+++ b/scripts/edxapp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/edxapp_restart.sh
+++ b/scripts/edxapp_restart.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/edxapp_upgrade.sh
+++ b/scripts/edxapp_upgrade.sh
@@ -1,14 +1,19 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
+# Acquire lock using script itself as lockfile.
+# Exit if script in use.
+exec 200<$0
+flock -n 200 || { echo "Another upgrade is already in progress. Double-check HipChat."; exit 1; }
+
 npm install
-pip install -r /edx/app/edxapp/edx-platform/requirements/edx/pre.txt
-pip install -r /edx/app/edxapp/edx-platform/requirements/edx/base.txt
-pip install -r /edx/app/edxapp/edx-platform/requirements/edx/github.txt
-pip install -r /edx/app/edxapp/edx-platform/requirements/edx/edx-private.txt
-pip install -r /edx/app/edxapp/edx-platform/requirements/edx/local.txt
-pip install -r /edx/app/edxapp/edx-platform/requirements/edx/post.txt
+pip install -Ur /edx/app/edxapp/edx-platform/requirements/edx/pre.txt
+pip install -Ur /edx/app/edxapp/edx-platform/requirements/edx/base.txt
+pip install -Ur /edx/app/edxapp/edx-platform/requirements/edx/github.txt
+pip install -Ur /edx/app/edxapp/edx-platform/requirements/edx/edx-private.txt
+pip install -Ur /edx/app/edxapp/edx-platform/requirements/edx/local.txt
+pip install -Ur /edx/app/edxapp/edx-platform/requirements/edx/post.txt
 
 python manage.py cms migrate --settings=aws
 python manage.py lms migrate --settings=aws

--- a/scripts/set_aliases.sh
+++ b/scripts/set_aliases.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # This file should go in the /etc/profile.d directory.
 
 source /home/douglashall/.bash_aliases

--- a/scripts/sync_salesforce.sh
+++ b/scripts/sync_salesforce.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source /home/douglashall/venvs/edx-salesforce/bin/activate
 cd /home/douglashall/src/edx-salesforce

--- a/scripts/themes.sh
+++ b/scripts/themes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
1. No one can accidentally run the upgrade script in overlap now.
2. Also added the `-U` to `pip`, because otherwise I noticed edx-enterprise doesn't properly get updated.
3. Made `*.sh` files executable.
4. Used `/usr/bin/env bash` to make script portable to environments without `/bin/bash`.
